### PR TITLE
Spinner/#19 color detection

### DIFF
--- a/src/main/java/org/frc5687/infiniterecharge/robot/Constants.java
+++ b/src/main/java/org/frc5687/infiniterecharge/robot/Constants.java
@@ -88,8 +88,8 @@ public class Constants {
     }
 
     public class Spinner {
-<<<<<<< HEAD
-        public static final double MOTOR_PERCENT_SPEED = 0.5;
+        public static final double MOTOR_PERCENT_SPEED = 0.5; // TODO: Need a real value here!
+        public static final double COLOR_TOLERANCE = 0.15;
     }
 
     public class RotarySwitch {
@@ -105,15 +105,5 @@ public class Constants {
     public class Indexer {
         public static final boolean INVERTED = false;
         public static final double ADVANCE_SPEED = 0.5; // TODO: Need a real value here!
-
-        public static final double SPEED = 0.5;
-        // TODO We may prefer these to be a single constant we can tweak?
-        public static final double RED_DETECTION_THRESHOLD = 0.31;
-        public static final double GREEN_DETECTION_THRESHOLD = 0.37;
-        public static final double BLUE_DETECTION_THRESHOLD = 0.26;
-
-        //public static final double HAS_COLOR_THRESHOLD = 0.27;
-        //public static final double LACKS_COLOR_THRESHOLD = 0.18;
-
     }
 }

--- a/src/main/java/org/frc5687/infiniterecharge/robot/Constants.java
+++ b/src/main/java/org/frc5687/infiniterecharge/robot/Constants.java
@@ -88,6 +88,7 @@ public class Constants {
     }
 
     public class Spinner {
+<<<<<<< HEAD
         public static final double MOTOR_PERCENT_SPEED = 0.5;
     }
 
@@ -104,5 +105,15 @@ public class Constants {
     public class Indexer {
         public static final boolean INVERTED = false;
         public static final double ADVANCE_SPEED = 0.5; // TODO: Need a real value here!
+
+        public static final double SPEED = 0.5;
+        // TODO We may prefer these to be a single constant we can tweak?
+        public static final double RED_DETECTION_THRESHOLD = 0.31;
+        public static final double GREEN_DETECTION_THRESHOLD = 0.37;
+        public static final double BLUE_DETECTION_THRESHOLD = 0.26;
+
+        //public static final double HAS_COLOR_THRESHOLD = 0.27;
+        //public static final double LACKS_COLOR_THRESHOLD = 0.18;
+
     }
 }

--- a/src/main/java/org/frc5687/infiniterecharge/robot/Constants.java
+++ b/src/main/java/org/frc5687/infiniterecharge/robot/Constants.java
@@ -89,7 +89,7 @@ public class Constants {
 
     public class Spinner {
         public static final double MOTOR_PERCENT_SPEED = 0.5; // TODO: Need a real value here!
-        public static final double COLOR_TOLERANCE = 0.15;
+        public static final double COLOR_TOLERANCE = 0.06;
     }
 
     public class RotarySwitch {

--- a/src/main/java/org/frc5687/infiniterecharge/robot/subsystems/Spinner.java
+++ b/src/main/java/org/frc5687/infiniterecharge/robot/subsystems/Spinner.java
@@ -73,16 +73,20 @@ public class Spinner extends OutliersSubsystem {
         return false;
     }
 
-    public boolean isRed() {
-        return false;
+    public int getNormalizedRed() {
+        return _colorSensor.getRed() / getColorSum();
     }
 
-    public boolean isBlue() {
-        return false;
+    public int getNormalizedGreen() {
+        return _colorSensor.getGreen() / getColorSum();
     }
 
-    public boolean isGreen() {
-        return false;
+    public int getNormalizedBlue() {
+        return _colorSensor.getBlue() / getColorSum();
+    }
+
+    public int getColorSum() {
+        return _colorSensor.getRed() + _colorSensor.getGreen() + _colorSensor.getBlue();
     }
 
     public void spin() {

--- a/src/main/java/org/frc5687/infiniterecharge/robot/subsystems/Spinner.java
+++ b/src/main/java/org/frc5687/infiniterecharge/robot/subsystems/Spinner.java
@@ -34,30 +34,6 @@ public class Spinner extends OutliersSubsystem {
         }
     }
 
-    public void raiseArm() {
-        _solenoid.set(DoubleSolenoid.Value.kForward);
-    }
-
-    public void lowerArm(){
-        _solenoid.set(DoubleSolenoid.Value.kReverse);
-    }
-
-    public boolean isRaised(){
-        return _solenoid.get().equals(DoubleSolenoid.Value.kForward);
-    }
-
-    public boolean isLowered(){
-        return _solenoid.get().equals(DoubleSolenoid.Value.kReverse);
-    }
-
-    public boolean isArmOff(){
-        return _solenoid.get().equals(DoubleSolenoid.Value.kOff);
-    }
-
-    public void armOff() {
-        _solenoid.set(DoubleSolenoid.Value.kOff);
-    }
-
     public enum Color {
         red(0),
         green(1),
@@ -71,6 +47,20 @@ public class Spinner extends OutliersSubsystem {
         }
         public int getValue() {
             return _value;
+        }
+        public String toString() {
+            switch (_value) {
+                case 0:
+                    return "red";
+                case 1:
+                    return "green";
+                case 2:
+                    return "blue";
+                case 3:
+                    return "yellow";
+                default:
+                    return "unknown";
+            }
         }
     }
 
@@ -100,10 +90,10 @@ public class Spinner extends OutliersSubsystem {
         setDefaultCommand(new DriveSpinner(this));
 
         // TODO(mike) might want to move to Constants.java ?
-        _swatches.put(Color.red, new Rgb(0.58, 0.31, 0.10));
-        _swatches.put(Color.yellow, new Rgb(0.36, 0.53, 0.10));
+        _swatches.put(Color.red, new Rgb(0.60, 0.31, 0.08));
+        _swatches.put(Color.yellow, new Rgb(0.40, 0.49, 0.10));
         _swatches.put(Color.green, new Rgb(0.21, 0.56, 0.23));
-        _swatches.put(Color.blue, new Rgb(0.15, 0.43, 0.45));
+        _swatches.put(Color.blue, new Rgb(0.21, 0.45, 0.35));
     }
 
     public Color getColor() {
@@ -117,6 +107,30 @@ public class Spinner extends OutliersSubsystem {
             return Color.yellow;
         }
         return Color.unknown;
+    }
+
+    public void raiseArm() {
+        _solenoid.set(DoubleSolenoid.Value.kForward);
+    }
+
+    public void lowerArm(){
+        _solenoid.set(DoubleSolenoid.Value.kReverse);
+    }
+
+    public boolean isRaised(){
+        return _solenoid.get().equals(DoubleSolenoid.Value.kForward);
+    }
+
+    public boolean isLowered(){
+        return _solenoid.get().equals(DoubleSolenoid.Value.kReverse);
+    }
+
+    public boolean isArmOff(){
+        return _solenoid.get().equals(DoubleSolenoid.Value.kOff);
+    }
+
+    public void armOff() {
+        _solenoid.set(DoubleSolenoid.Value.kOff);
     }
 
     public void spin() {
@@ -142,7 +156,7 @@ public class Spinner extends OutliersSubsystem {
         metric("Spinner/NormRed", _colorSensor.getColor().red);
         metric("Spinner/NormGreen", _colorSensor.getColor().green);
         metric("Spinner/NormBlue", _colorSensor.getColor().blue);
-        metric("Spinner/Color", getColor().getValue());
+        metric("Spinner/Color", getColor().toString());
         metric("Spinner/IR", _colorSensor.getIR());
         metric("Spinner/Proximity", _colorSensor.getProximity());
         metric("Spinner/ArmIsRaised", isRaised());

--- a/src/main/java/org/frc5687/infiniterecharge/robot/subsystems/Spinner.java
+++ b/src/main/java/org/frc5687/infiniterecharge/robot/subsystems/Spinner.java
@@ -77,16 +77,21 @@ public class Spinner extends OutliersSubsystem {
         return _colorSensor.getRed() / getColorSum();
     }
 
-    public int getNormalizedGreen() {
-        return _colorSensor.getGreen() / getColorSum();
+    public Color getColor() {
+        if (redDetected() && !greenDetected()) {
+            return Color.red;
+        } else if (greenDetected() && !redDetected() && !blueDetected()) {
+            return Color.green;
+        } else if (blueDetected()) {
+            return Color.blue;
+        } else if (redDetected() && greenDetected() && !blueDetected()) {
+            return Color.yellow;
+        }
+        return Color.unknown;
     }
 
-    public int getNormalizedBlue() {
-        return _colorSensor.getBlue() / getColorSum();
-    }
-
-    public int getColorSum() {
-        return _colorSensor.getRed() + _colorSensor.getGreen() + _colorSensor.getBlue();
+    private boolean redDetected() {
+        return _colorSensor.getColor().red >= Constants.Spinner.RED_DETECTION_THRESHOLD;
     }
 
     public void spin() {
@@ -95,6 +100,15 @@ public class Spinner extends OutliersSubsystem {
 
     public void stop() {
         _motorController.set(ControlMode.PercentOutput, 0);
+    }
+
+    private boolean greenDetected() {
+        return _colorSensor.getColor().green >= Constants.Spinner.GREEN_DETECTION_THRESHOLD;
+
+    }
+
+    private boolean blueDetected() {
+        return _colorSensor.getColor().blue >= Constants.Spinner.BLUE_DETECTION_THRESHOLD;
     }
 
     @Override


### PR DESCRIPTION
Adds a color detection algorithm to the Spinner subsystem... there's a COLOR_TOLERANCE constant in Constants.java that can be tweaked to tune for how close the measured value needs to match the value we read from the color swatch... 0.06 seems to work pretty well, it still occasionally gets confused and thinks that it sees yellow when it's on the line between green and red - I think the only way to fix this will be to do a multiple-sample approach like Ben was describing yesterday.

There's a silly inner class for RGB values that I'm not in love with but whatev.

I've also done a little cleanup - put the ctor at the top of the class and public methods after that.